### PR TITLE
feature: use pprint for metrics logging of list-likes

### DIFF
--- a/workflow/ignite/handlers/metrics_logger.py
+++ b/workflow/ignite/handlers/metrics_logger.py
@@ -1,5 +1,6 @@
 from tqdm import tqdm
 from ignite.engine import Events
+import pprint
 
 from workflow.torch.is_float import is_float
 
@@ -27,7 +28,7 @@ class MetricsLogger:
                     padding = ' ' * (target_len - len(metric_name))
                     if hasattr(value, '__len__'):
                         tqdm.write(f'  {metric_name}:')
-                        tqdm.write(str(value))
+                        tqdm.write(pprint.pformat(value))
                     elif is_float(value):
                         if abs(value) > 1e-4 or value == 0:
                             tqdm.write(


### PR DESCRIPTION
Old output:
```
[(15, tensor([172.4846, 143.2534, 106.8790])), (21, tensor([144.2608, 118.4739,  82.0828])), (33, tensor([207.3872, 179.7313, 144.5106])), (48, tensor([138.3365, 111.9792,  75.6738])), (63, tensor([91.4388, 76.3457, 43.3649])), (26, tensor([189.8004, 142.7215,  89.1758])), (44, tensor([57.4036, 54.4350, 48.4170]))]
```
New:
```
[(15, tensor([172.4846, 143.2534, 106.8790])),
 (21, tensor([144.2608, 118.4739,  82.0828])),
 (33, tensor([207.3872, 179.7313, 144.5106])),
 (48, tensor([138.3365, 111.9792,  75.6738])),
 (63, tensor([91.4388, 76.3457, 43.3649])),
 (26, tensor([189.8004, 142.7215,  89.1758])),
 (44, tensor([57.4036, 54.4350, 48.4170]))]
```
Tensors are printed the same as before with this update.