### PR TITLE
feature: add n_saved parameter to checkpoint

### DIFF
--- a/workflow/ignite/handlers/model_checkpoint.py
+++ b/workflow/ignite/handlers/model_checkpoint.py
@@ -9,12 +9,12 @@ class ModelCheckpoint:
     dirname = 'checkpoints'
     filename_prefix = 'model'
 
-    def __init__(self, model_score_function=None):
+    def __init__(self, model_score_function=None, n_saved=1):
         self.model_checkpoint = ignite.handlers.ModelCheckpoint(
             dirname=self.dirname,
             filename_prefix=self.filename_prefix,
             score_function=model_score_function,
-            n_saved=1,
+            n_saved=n_saved,
             require_empty=False,
         )
 

--- a/workflow/ignite/handlers/model_score.py
+++ b/workflow/ignite/handlers/model_score.py
@@ -16,6 +16,7 @@ class ModelScore:
         evaluator_metrics,
         tensorboard_logger,
         config,
+        n_saved=1,
     ):
         '''
         Model score brings together several handlers related to model score.
@@ -30,6 +31,7 @@ class ModelScore:
         self.evaluator_metrics = evaluator_metrics
         self.tensorboard_logger = tensorboard_logger
         self.config = config
+        self.n_saved = n_saved,
 
     def attach(self, trainer, evaluators):
         def _model_score_function(*args, **kwargs):
@@ -64,7 +66,7 @@ class ModelScore:
                 BestModelTrigger.Event,
             )
 
-        ModelCheckpoint(_model_score_function).attach(
+        ModelCheckpoint(_model_score_function, n_saved=n_saved).attach(
             trainer, self.checkpoint_state
         )
 


### PR DESCRIPTION
Just a suggestion. It can be useful in some cases to be able to save a model every n:th epoch (accomplished for example by setting `model_score_function=trainer.state.epoch // save_interval` and `n_saved=None`).